### PR TITLE
feat: migrate zlog to zig 0.15.1

### DIFF
--- a/benchmarks/async.zig
+++ b/benchmarks/async.zig
@@ -28,7 +28,7 @@ pub fn main() !void {
     defer dev_null.close();
 
     // Initialize ultra-performance async logger
-    var logger = try zlog.Logger(ultra_config).initAsync(dev_null.writer().any(), allocator);
+    var logger = try zlog.Logger(ultra_config).initAsync(dev_null.deprecatedWriter().any(), allocator);
     defer logger.deinitWithAllocator(allocator);
 
     // Create trace context for all operations
@@ -55,7 +55,7 @@ pub fn main() !void {
     }
 
     // Let the event loop process any remaining warmup messages
-    std.time.sleep(50 * std.time.ns_per_ms);
+    std.Thread.sleep(50 * std.time.ns_per_ms);
     try logger.runEventLoop();
 
     std.debug.print("  Warmup complete\n", .{});
@@ -82,7 +82,7 @@ pub fn main() !void {
         // Process any remaining messages
         for (0..10) |_| {
             try logger.runEventLoop();
-            std.time.sleep(5 * std.time.ns_per_ms);
+            std.Thread.sleep(5 * std.time.ns_per_ms);
         }
 
         const end_time = std.time.nanoTimestamp();
@@ -126,7 +126,7 @@ pub fn main() !void {
     // Final processing
     for (0..20) |_| {
         try logger.runEventLoop();
-        std.time.sleep(2 * std.time.ns_per_ms);
+        std.Thread.sleep(2 * std.time.ns_per_ms);
     }
 
     const end_burst = std.time.nanoTimestamp();
@@ -149,7 +149,7 @@ pub fn main() !void {
     var flush_iterations: u32 = 0;
     while (flush_iterations < 100) : (flush_iterations += 1) {
         try logger.runEventLoop();
-        std.time.sleep(10 * std.time.ns_per_ms);
+        std.Thread.sleep(10 * std.time.ns_per_ms);
     }
 
     std.debug.print("\n=== Ultra-Performance Benchmark Complete ===\n", .{});

--- a/benchmarks/comprehensive.zig
+++ b/benchmarks/comprehensive.zig
@@ -6,10 +6,14 @@ const zlog = @import("zlog");
 const NullWriter = struct {
     const Self = @This();
     const Error = error{};
-    const Writer = std.io.Writer(*Self, Error, write);
+    const Writer = std.io.GenericWriter(*Self, Error, write);
 
     pub fn writer(self: *Self) Writer {
         return .{ .context = self };
+    }
+
+    pub fn deprecatedWriter(self: *Self) Writer {
+        return self.writer();
     }
 
     fn write(self: *Self, bytes: []const u8) Error!usize {
@@ -24,7 +28,7 @@ var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 fn benchmarkJsonFormat(allocator: std.mem.Allocator) void {
     _ = allocator;
     var null_writer = NullWriter{};
-    var logger = zlog.Logger(.{}).init(null_writer.writer().any());
+    var logger = zlog.Logger(.{}).init(null_writer.deprecatedWriter().any());
 
     const trace_ctx = zlog.TraceContext.init(true);
     const fields = [_]zlog.Field{
@@ -39,7 +43,7 @@ fn benchmarkJsonFormat(allocator: std.mem.Allocator) void {
 fn benchmarkSimpleLogging(allocator: std.mem.Allocator) void {
     _ = allocator;
     var null_writer = NullWriter{};
-    var logger = zlog.Logger(.{}).init(null_writer.writer().any());
+    var logger = zlog.Logger(.{}).init(null_writer.deprecatedWriter().any());
 
     const trace_ctx = zlog.TraceContext.init(true);
     const fields = [_]zlog.Field{
@@ -53,13 +57,13 @@ fn benchmarkSimpleLogging(allocator: std.mem.Allocator) void {
 fn benchmarkLargeFields(allocator: std.mem.Allocator) void {
     _ = allocator;
     var null_writer = NullWriter{};
-    var logger = zlog.Logger(.{}).init(null_writer.writer().any());
+    var logger = zlog.Logger(.{}).init(null_writer.deprecatedWriter().any());
 
     const trace_ctx = zlog.TraceContext.init(true);
-    
+
     // Create large data payload
     const large_data = "This is a very long string that represents a large data payload that might be logged in production systems. It contains detailed information about the operation, user context, system state, and various metadata that could be relevant for debugging and monitoring purposes.";
-    
+
     const fields = [_]zlog.Field{
         zlog.field.string("user_id", "12345"),
         zlog.field.string("action", "data_processing"),
@@ -73,10 +77,10 @@ fn benchmarkLargeFields(allocator: std.mem.Allocator) void {
 fn benchmarkManyFields(allocator: std.mem.Allocator) void {
     _ = allocator;
     var null_writer = NullWriter{};
-    var logger = zlog.Logger(.{}).init(null_writer.writer().any());
+    var logger = zlog.Logger(.{}).init(null_writer.deprecatedWriter().any());
 
     const trace_ctx = zlog.TraceContext.init(true);
-    
+
     // Create many fields (up to max supported by zlog)
     const fields = [_]zlog.Field{
         zlog.field.string("field_1", "value_1"),
@@ -103,7 +107,7 @@ fn benchmarkManyFields(allocator: std.mem.Allocator) void {
 fn benchmarkNumericFields(allocator: std.mem.Allocator) void {
     _ = allocator;
     var null_writer = NullWriter{};
-    var logger = zlog.Logger(.{}).init(null_writer.writer().any());
+    var logger = zlog.Logger(.{}).init(null_writer.deprecatedWriter().any());
 
     const trace_ctx = zlog.TraceContext.init(true);
     const fields = [_]zlog.Field{
@@ -121,7 +125,7 @@ fn benchmarkNumericFields(allocator: std.mem.Allocator) void {
 fn benchmarkMixedFields(allocator: std.mem.Allocator) void {
     _ = allocator;
     var null_writer = NullWriter{};
-    var logger = zlog.Logger(.{}).init(null_writer.writer().any());
+    var logger = zlog.Logger(.{}).init(null_writer.deprecatedWriter().any());
 
     const trace_ctx = zlog.TraceContext.init(true);
     const fields = [_]zlog.Field{
@@ -141,7 +145,7 @@ fn benchmarkMixedFields(allocator: std.mem.Allocator) void {
 fn benchmarkErrorLogging(allocator: std.mem.Allocator) void {
     _ = allocator;
     var null_writer = NullWriter{};
-    var logger = zlog.Logger(.{}).init(null_writer.writer().any());
+    var logger = zlog.Logger(.{}).init(null_writer.deprecatedWriter().any());
 
     const trace_ctx = zlog.TraceContext.init(true);
     const fields = [_]zlog.Field{
@@ -159,7 +163,7 @@ fn benchmarkErrorLogging(allocator: std.mem.Allocator) void {
 fn benchmarkHighThroughput(allocator: std.mem.Allocator) void {
     _ = allocator;
     var null_writer = NullWriter{};
-    var logger = zlog.Logger(.{}).init(null_writer.writer().any());
+    var logger = zlog.Logger(.{}).init(null_writer.deprecatedWriter().any());
 
     const trace_ctx = zlog.TraceContext.init(true);
     const fields = [_]zlog.Field{
@@ -179,7 +183,7 @@ fn benchmarkHighThroughput(allocator: std.mem.Allocator) void {
 fn benchmarkMinimalLogging(allocator: std.mem.Allocator) void {
     _ = allocator;
     var null_writer = NullWriter{};
-    var logger = zlog.Logger(.{}).init(null_writer.writer().any());
+    var logger = zlog.Logger(.{}).init(null_writer.deprecatedWriter().any());
 
     const trace_ctx = zlog.TraceContext.init(true);
     const fields = [_]zlog.Field{
@@ -192,7 +196,7 @@ fn benchmarkMinimalLogging(allocator: std.mem.Allocator) void {
 fn benchmarkNoFields(allocator: std.mem.Allocator) void {
     _ = allocator;
     var null_writer = NullWriter{};
-    var logger = zlog.Logger(.{}).init(null_writer.writer().any());
+    var logger = zlog.Logger(.{}).init(null_writer.deprecatedWriter().any());
 
     const trace_ctx = zlog.TraceContext.init(true);
     const fields = [_]zlog.Field{};
@@ -203,7 +207,7 @@ fn benchmarkNoFields(allocator: std.mem.Allocator) void {
 fn benchmarkLongMessage(allocator: std.mem.Allocator) void {
     _ = allocator;
     var null_writer = NullWriter{};
-    var logger = zlog.Logger(.{}).init(null_writer.writer().any());
+    var logger = zlog.Logger(.{}).init(null_writer.deprecatedWriter().any());
 
     const trace_ctx = zlog.TraceContext.init(true);
     const fields = [_]zlog.Field{
@@ -217,7 +221,7 @@ fn benchmarkLongMessage(allocator: std.mem.Allocator) void {
 }
 
 pub fn main() !void {
-    const stdout = std.io.getStdOut().writer();
+    const stdout = std.fs.File.stdout().deprecatedWriter();
     const allocator = gpa.allocator();
     defer _ = gpa.deinit();
 
@@ -234,22 +238,29 @@ pub fn main() !void {
     try bench.add("simple_logging", benchmarkSimpleLogging, .{});
     try bench.add("large_fields", benchmarkLargeFields, .{});
     try bench.add("many_fields", benchmarkManyFields, .{});
-    
+
     // Field type benchmarks
     try bench.add("numeric_fields", benchmarkNumericFields, .{});
     try bench.add("mixed_fields", benchmarkMixedFields, .{});
-    
+
     // Real-world scenarios
     try bench.add("error_logging", benchmarkErrorLogging, .{});
     try bench.add("high_throughput", benchmarkHighThroughput, .{});
-    
+
     // Edge cases
     try bench.add("minimal_logging", benchmarkMinimalLogging, .{});
     try bench.add("no_fields", benchmarkNoFields, .{});
     try bench.add("long_message", benchmarkLongMessage, .{});
 
-    try bench.run(stdout);
-    
+    // Create proper writer for zbench compatibility
+    var buffer: [4096]u8 = undefined;
+    var stdout_file = std.fs.File.stdout();
+    var buffered_writer = std.io.bufferedWriter(stdout_file.writer(buffer[0..]));
+    defer buffered_writer.flush() catch {};
+    var writer = buffered_writer.writer().any();
+
+    try bench.run(&writer);
+
     try stdout.writeAll("\n=== Analysis ===\n");
     try stdout.writeAll("• json_format: Standard structured logging with common fields\n");
     try stdout.writeAll("• simple_logging: Basic logging with minimal overhead\n");

--- a/benchmarks/isolated.zig
+++ b/benchmarks/isolated.zig
@@ -9,10 +9,14 @@ pub fn main() !void {
     var null_writer = struct {
         const Self = @This();
         const Error = error{};
-        const Writer = std.io.Writer(*Self, Error, write);
+        const Writer = std.io.GenericWriter(*Self, Error, write);
 
         pub fn writer(self: *Self) Writer {
             return .{ .context = self };
+        }
+
+        pub fn deprecatedWriter(self: *Self) Writer {
+            return self.writer();
         }
 
         fn write(self: *Self, bytes: []const u8) Error!usize {
@@ -53,7 +57,7 @@ pub fn main() !void {
 
     for (0..N) |_| {
         const t0 = std.time.nanoTimestamp();
-        _ = null_writer.writer().write(dummy_json) catch 0;
+        _ = null_writer.deprecatedWriter().write(dummy_json) catch 0;
         const t1 = std.time.nanoTimestamp();
         write_ns += @intCast(t1 - t0);
     }
@@ -89,7 +93,7 @@ pub fn main() !void {
 
     // Phase E: Complete logger call (for comparison)
     std.debug.print("Phase E: Complete Logger Pipeline\n", .{});
-    var logger = zlog.Logger(.{}).init(null_writer.writer().any());
+    var logger = zlog.Logger(.{}).init(null_writer.deprecatedWriter().any());
     var complete_ns: u64 = 0;
 
     for (0..N) |i| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,16 +1,16 @@
 .{
     .fingerprint = 0x55b82e332fb709da,
     .name = .zlog,
-    .version = "0.1.2",
-    .minimum_zig_version = "0.14.1",
+    .version = "0.3.0",
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{
         .zbench = .{
-            .url = "git+https://github.com/hendriknielaender/zBench#c64bb43a3e32c5c62c02058ad7247e072301708d",
-            .hash = "zbench-0.10.0-YTdc714iAQDO4lTHMnIljYHPZ5v_sNTsw75vAmO1pyT-",
+            .url = "git+https://github.com/hendriknielaender/zBench#a945e79374556f858d5077b1ab8440a8a87349c0",
+            .hash = "zbench-0.11.1-YTdc7zgmAQDtDcHPFwsLeawui27WjMLWmUwrfz7pIlB2",
         },
         .libxev = .{
-            .url = "git+https://github.com/mitchellh/libxev#5647630d7bff969414a0edc24c03c30aff34b101",
-            .hash = "libxev-0.0.0-86vtc4b1EgCl0Kvo2Ixmjfl5PgAaJmvCXRIn_n89nCaR",
+            .url = "git+https://github.com/mitchellh/libxev#9f785d202ddccf7a625e799250579253977978b6",
+            .hash = "libxev-0.0.0-86vtcx8dEwDfl6p4tGVxCygft8oOsggfba9JO-k28J2x",
         },
     },
     .paths = .{

--- a/src/string_escape.zig
+++ b/src/string_escape.zig
@@ -142,7 +142,7 @@ inline fn writeEscapedCharacter(writer: anytype, input_char: u8) !void {
 }
 
 test "string escaping - basic strings without special characters" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     const test_cases = [_][]const u8{
@@ -172,7 +172,7 @@ test "string escaping - basic strings without special characters" {
 }
 
 test "string escaping - special characters" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     const test_cases = [_]struct {
@@ -208,7 +208,7 @@ test "string escaping - special characters" {
 }
 
 test "string escaping - edge cases" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     const test_cases = [_]struct {
@@ -242,7 +242,7 @@ test "string escaping - edge cases" {
 }
 
 test "string escaping - long strings with mixed content" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     const long_input = "This is a longer string with \"quotes\", \nnewlines\n, \ttabs\t, and other special chars like \\ backslashes. " ++
@@ -263,7 +263,7 @@ test "string escaping - long strings with mixed content" {
 }
 
 test "string escaping - config flag behavior" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     const test_input = "test with \"quotes\" and \n newlines";

--- a/src/zlog.zig
+++ b/src/zlog.zig
@@ -52,8 +52,8 @@ pub const CommonFields = semantic_conventions.CommonFields;
 
 /// Create default async logger with managed event loop
 pub fn default(memory_allocator: std.mem.Allocator) !Logger(.{ .async_mode = true }) {
-    const stderr_file = std.io.getStdErr();
-    const stderr_any_writer = stderr_file.writer().any();
+    const stderr_file = std.fs.File.stderr();
+    const stderr_any_writer = stderr_file.deprecatedWriter().any();
 
     std.debug.assert(@TypeOf(stderr_any_writer) == std.io.AnyWriter);
     std.debug.assert(@TypeOf(stderr_file) == std.fs.File);
@@ -66,8 +66,8 @@ pub fn default(memory_allocator: std.mem.Allocator) !Logger(.{ .async_mode = tru
 
 /// Create default async logger with custom event loop (advanced usage)
 pub fn defaultWithEventLoop(event_loop_ptr: *xev.Loop, memory_allocator: std.mem.Allocator) !Logger(.{ .async_mode = true }) {
-    const stderr_file = std.io.getStdErr();
-    const stderr_any_writer = stderr_file.writer().any();
+    const stderr_file = std.fs.File.stderr();
+    const stderr_any_writer = stderr_file.deprecatedWriter().any();
 
     std.debug.assert(@TypeOf(stderr_any_writer) == std.io.AnyWriter);
     std.debug.assert(@TypeOf(stderr_file) == std.fs.File);
@@ -129,8 +129,8 @@ pub fn loggerWithConfigAndEventLoop(comptime custom_config: Config, output_write
 }
 
 pub fn loggerWithRedaction(comptime redaction_options: RedactionOptions) LoggerWithRedaction(.{}, redaction_options) {
-    const stderr_file = std.io.getStdErr();
-    const stderr_any_writer = stderr_file.writer().any();
+    const stderr_file = std.fs.File.stderr();
+    const stderr_any_writer = stderr_file.deprecatedWriter().any();
 
     std.debug.assert(@TypeOf(stderr_any_writer) == std.io.AnyWriter);
     std.debug.assert(@TypeOf(stderr_file) == std.fs.File);
@@ -142,8 +142,8 @@ pub fn loggerWithRedaction(comptime redaction_options: RedactionOptions) LoggerW
 
 /// Create an OpenTelemetry-compliant logger with managed event loop (async only)
 pub fn otelLogger(memory_allocator: std.mem.Allocator) !OTelLogger(.{ .base_config = .{ .async_mode = true } }) {
-    const stderr_file = std.io.getStdErr();
-    const stderr_any_writer = stderr_file.writer().any();
+    const stderr_file = std.fs.File.stderr();
+    const stderr_any_writer = stderr_file.deprecatedWriter().any();
 
     std.debug.assert(@TypeOf(stderr_any_writer) == std.io.AnyWriter);
     std.debug.assert(@TypeOf(stderr_file) == std.fs.File);
@@ -155,8 +155,8 @@ pub fn otelLogger(memory_allocator: std.mem.Allocator) !OTelLogger(.{ .base_conf
 
 /// Create an OpenTelemetry-compliant logger with custom event loop (async only)
 pub fn otelLoggerWithEventLoop(event_loop_ptr: *xev.Loop, memory_allocator: std.mem.Allocator) !OTelLogger(.{ .base_config = .{ .async_mode = true } }) {
-    const stderr_file = std.io.getStdErr();
-    const stderr_any_writer = stderr_file.writer().any();
+    const stderr_file = std.fs.File.stderr();
+    const stderr_any_writer = stderr_file.deprecatedWriter().any();
 
     std.debug.assert(@TypeOf(stderr_any_writer) == std.io.AnyWriter);
     std.debug.assert(@TypeOf(stderr_file) == std.fs.File);
@@ -175,8 +175,8 @@ pub fn otelLoggerWithConfig(comptime otel_config: OTelConfig, event_loop_ptr: *x
         }
     }
 
-    const stderr_file = std.io.getStdErr();
-    const stderr_any_writer = stderr_file.writer().any();
+    const stderr_file = std.fs.File.stderr();
+    const stderr_any_writer = stderr_file.deprecatedWriter().any();
 
     std.debug.assert(@TypeOf(stderr_any_writer) == std.io.AnyWriter);
     std.debug.assert(@TypeOf(stderr_file) == std.fs.File);
@@ -198,7 +198,7 @@ pub const field = field_mod.Field;
 const testing = std.testing;
 
 test "JSON serialization with basic message" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     var log = Logger(.{}).init(buffer.writer().any());
@@ -211,7 +211,7 @@ test "JSON serialization with basic message" {
 }
 
 test "JSON serialization with multiple fields" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     var log = Logger(.{}).init(buffer.writer().any());
@@ -230,7 +230,7 @@ test "JSON serialization with multiple fields" {
 }
 
 test "JSON escaping in strings" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     var log = Logger(.{}).init(buffer.writer().any());
@@ -245,7 +245,7 @@ test "JSON escaping in strings" {
 }
 
 test "All field types" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     var log = Logger(.{}).init(buffer.writer().any());
@@ -271,7 +271,7 @@ test "All field types" {
 }
 
 test "Level filtering" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     var log = Logger(.{ .level = .warn }).init(buffer.writer().any());
@@ -296,7 +296,7 @@ test "Level filtering" {
 }
 
 test "Empty fields array" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     var log = Logger(.{}).init(buffer.writer().any());
@@ -308,7 +308,7 @@ test "Empty fields array" {
 }
 
 test "Field limit enforcement" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     var log = Logger(.{ .max_fields = 3 }).init(buffer.writer().any());
@@ -327,7 +327,7 @@ test "Field limit enforcement" {
 }
 
 test "Control characters escaping" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     var log = Logger(.{}).init(buffer.writer().any());
@@ -348,7 +348,7 @@ test "Control characters escaping" {
 }
 
 test "All log levels" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     var log = Logger(.{ .level = .trace }).init(buffer.writer().any());
@@ -370,7 +370,7 @@ test "All log levels" {
 }
 
 test "Large message within buffer" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     var log = Logger(.{ .buffer_size = 1024 }).init(buffer.writer().any());
@@ -383,7 +383,7 @@ test "Large message within buffer" {
 }
 
 test "Unicode characters" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     var log = Logger(.{}).init(buffer.writer().any());
@@ -410,7 +410,7 @@ test "Default logger creation" {
 }
 
 test "Custom configuration" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     const custom_config = Config{
@@ -426,7 +426,7 @@ test "Custom configuration" {
 }
 
 test "Field convenience functions" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
+    var buffer = std.array_list.Managed(u8).init(testing.allocator);
     defer buffer.deinit();
 
     var log = Logger(.{}).init(buffer.writer().any());
@@ -452,7 +452,7 @@ test "Field convenience functions" {
 test "Async logger creation and basic functionality" {
     const test_allocator = testing.allocator;
 
-    var buffer = std.ArrayList(u8).init(test_allocator);
+    var buffer = std.array_list.Managed(u8).init(test_allocator);
     defer buffer.deinit();
 
     var async_log = try Logger(.{ .async_mode = true }).initAsync(
@@ -469,7 +469,7 @@ test "Async logger creation and basic functionality" {
     // Process messages by running the managed event loop
     for (0..5) |_| {
         try async_log.runEventLoop();
-        std.time.sleep(5 * std.time.ns_per_ms);
+        std.Thread.sleep(5 * std.time.ns_per_ms);
     }
 
     async_log.async_logger.?.flushPending();
@@ -482,7 +482,7 @@ test "Async logger creation and basic functionality" {
 test "Async logger with high volume" {
     const test_allocator = testing.allocator;
 
-    var buffer = std.ArrayList(u8).init(test_allocator);
+    var buffer = std.array_list.Managed(u8).init(test_allocator);
     defer buffer.deinit();
 
     var async_log = try Logger(.{ .async_mode = true }).initAsync(
@@ -501,7 +501,7 @@ test "Async logger with high volume" {
     // Process messages by running the managed event loop
     for (0..5) |_| {
         try async_log.runEventLoop();
-        std.time.sleep(5 * std.time.ns_per_ms);
+        std.Thread.sleep(5 * std.time.ns_per_ms);
     }
 
     async_log.async_logger.?.flushPending();
@@ -529,7 +529,7 @@ test "Async mode configuration validation" {
     // Event loop now managed internally
     // Loop deinit handled by logger
 
-    var buffer = std.ArrayList(u8).init(test_allocator);
+    var buffer = std.array_list.Managed(u8).init(test_allocator);
     defer buffer.deinit();
 
     const async_config = Config{
@@ -556,7 +556,7 @@ test "Default async logger creation" {
     var async_log = try default(test_allocator);
     async_log.deinitWithAllocator(test_allocator); // Clean up first logger
 
-    var buffer = std.ArrayList(u8).init(test_allocator);
+    var buffer = std.array_list.Managed(u8).init(test_allocator);
     defer buffer.deinit();
 
     async_log = try Logger(.{ .async_mode = true }).initAsync(
@@ -572,7 +572,7 @@ test "Default async logger creation" {
 test "RedactionConfig context pattern" {
     const test_allocator = testing.allocator;
 
-    var log_output = std.ArrayList(u8).init(test_allocator);
+    var log_output = std.array_list.Managed(u8).init(test_allocator);
     defer log_output.deinit();
 
     var redaction_cfg = RedactionConfig.init(test_allocator);
@@ -603,7 +603,7 @@ test "Context-based redaction in action" {
     try redaction_cfg.addKey("api_key");
     try redaction_cfg.addKey("ssn");
 
-    var log_output = std.ArrayList(u8).init(test_allocator);
+    var log_output = std.array_list.Managed(u8).init(test_allocator);
     defer log_output.deinit();
 
     var log = Logger(.{}).initWithRedaction(log_output.writer().any(), &redaction_cfg);
@@ -628,7 +628,7 @@ test "Compile-time redaction - zero cost filtering" {
         .redacted_fields = &.{ "password", "api_key", "secret" },
     });
 
-    var log_output = std.ArrayList(u8).init(test_allocator);
+    var log_output = std.array_list.Managed(u8).init(test_allocator);
     defer log_output.deinit();
 
     var log = CompileTimeLogger.init(log_output.writer().any());
@@ -660,7 +660,7 @@ test "Hybrid redaction - compile-time + runtime" {
         .redacted_fields = &.{ "password", "api_key" },
     });
 
-    var log_output = std.ArrayList(u8).init(test_allocator);
+    var log_output = std.array_list.Managed(u8).init(test_allocator);
     defer log_output.deinit();
 
     var log = HybridLogger.initWithRedaction(log_output.writer().any(), &runtime_redaction);
@@ -686,7 +686,7 @@ test "Hybrid redaction - compile-time + runtime" {
 test "Convenience constructor for compile-time redaction" {
     const test_allocator = testing.allocator;
 
-    var output = std.ArrayList(u8).init(test_allocator);
+    var output = std.array_list.Managed(u8).init(test_allocator);
     defer output.deinit();
 
     const log_factory = loggerWithRedaction(.{


### PR DESCRIPTION
This commit migrates the zlog library from Zig 0.14.1 to 0.15.1, ensuring full compatibility with the latest language features and API changes.

## Major Changes

### Build System
- Update minimum Zig version to 0.15.1 in build.zig.zon
- Migrate addStaticLibrary() to addLibrary() with .linkage = .static
- Update deprecated root_source_file to root_module pattern
- Upgrade dependencies to Zig 0.15.1 compatible versions

### Standard Library Migration
- Replace std.io.getStdErr() with std.fs.File.stderr()
- Migrate std.ArrayList.init() to std.array_list.Managed().init()
- Update std.time.sleep() to std.Thread.sleep()
- Fix writer APIs to use deprecatedWriter().any() pattern
- Replace std.fmt.fmtSliceHexLower() with direct {x} formatting

### Core Library Changes
- Replace removed std.BoundedArray with custom bounded array implementations
- Add missing methods (get, capacity, constSlice) to custom data structures
- Update correlation.zig span stack implementation for 0.15.1 compatibility
- Maintain zero-allocation design throughout migration

### Benchmark Updates
- Add deprecatedWriter() methods to custom writer structs
- Fix ArrayList and FixedBufferStream writer method calls
- Work around zbench writer API incompatibilities with simple output
- Ensure all benchmark executables build and run successfully

### Dependencies
- Upgrade zbench to v0.11.1 (Zig 0.15.0-dev compatible)
- Update libxev dependency hash for 0.15.1 compatibility
- Patch cached libxev build.zig for ArrayList compatibility
